### PR TITLE
Allow girder nginx root to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ do not allow this by default.
 | --------------------------- | -------- | -------------------- | ----------------------------------------------------------------------- |
 | `nginx_hostname`            | yes      |                      | The hostname of the site. `{{ inventory_hostname }}` may provide this.  |
 | `nginx_registration_email`  | no       | `girder@kitware.com` | The email address to register with Let's Encrypt for expiration alerts. |
+| `nginx_girder_location`     | no       | `/`                  | The path from which Girder will be served.                              |
 | `nginx_extra_server_config` | no       |                      | Any extra Nginx configuration to add to the `server` block for Girder.  |
 
 ## Dependencies

--- a/templates/girder.conf.j2
+++ b/templates/girder.conf.j2
@@ -23,7 +23,7 @@ server {
     large_client_header_buffers 10 20k;
 
     location {{ nginx_girder_location | default("/") }} {
-        proxy_pass http://localhost:8080;
+        proxy_pass http://localhost:8080/;
 
         proxy_http_version 1.1;
 

--- a/templates/girder.conf.j2
+++ b/templates/girder.conf.j2
@@ -23,6 +23,8 @@ server {
     large_client_header_buffers 10 20k;
 
     location {{ nginx_girder_location | default("/") }} {
+        # The trailing slash makes proxy_pass a URI, so Nginx will strip any
+        # nginx_girder_location prefix from requests passed to the proxy
         proxy_pass http://localhost:8080/;
 
         proxy_http_version 1.1;

--- a/templates/girder.conf.j2
+++ b/templates/girder.conf.j2
@@ -22,7 +22,7 @@ server {
 
     large_client_header_buffers 10 20k;
 
-    location / {
+    location {{ nginx_girder_location | default("/") }} {
         proxy_pass http://localhost:8080;
 
         proxy_http_version 1.1;


### PR DESCRIPTION
Many deployments use Girder as a backend & administrative service, with a deployment-specific web app as the user facing front page. In these cases, the normal Girder app is served out of a non-root path and the custom app will be served from the root. This variable makes that configuration straightforward.