### PR TITLE
Use HTTP 308 to redirect to preserve method

### DIFF
--- a/templates/base.conf.j2
+++ b/templates/base.conf.j2
@@ -12,7 +12,7 @@ server {
     server_name {{ nginx_hostname }};
 
     if ($host = {{ nginx_hostname }}) {
-        return 301 https://$host$request_uri;
+        return 308 https://$host$request_uri;
     }
     return 404;
 }


### PR DESCRIPTION
Some clients (perhaps incorrectly) change the HTTP method to GET on a 301 redirect, but will not do so on a 308.